### PR TITLE
section handle htmlentities

### DIFF
--- a/data-sources/datasource.union.php
+++ b/data-sources/datasource.union.php
@@ -451,7 +451,7 @@
 					);
 
 					$result->appendChild(
-						new XMLElement('section', $this->datasources[$handle]['section']->get('name'), array(
+						new XMLElement('section', htmlentities($this->datasources[$handle]['section']->get('name')), array(
 							'id' => $this->datasources[$handle]['section']->get('id'),
 							'handle' => $this->datasources[$handle]['section']->get('handle')
 						))


### PR DESCRIPTION
Yo, I had to add htmlentities() to the section handle processor as it was spitting the dreaded Symphony entity error otherwise (My section has an ampersand in it).

Not sure if this is the desired way to do it, but it works.
