### PR TITLE
Update interface for 2.4

### DIFF
--- a/assets/uniondatasource.datasources.css
+++ b/assets/uniondatasource.datasources.css
@@ -1,15 +1,16 @@
-.UnionDatasource .frame > ol > li header {
+
+.union-datasources .frame-header {
 	border-bottom: 0;
 	box-shadow: none;
 }
-.UnionDatasource .frame > ol > li .content {
-	padding:  0;
-}
-.UnionDatasource .frame > ol > li h4 a {
+
+.union-datasources .frame-header h4 a {
 	font-weight: normal;
 	margin-top: 0;
 	color: #3F69A5;
 }
-.UnionDatasource .frame > ol > li.ordering h4 a {
-	color: #FFF;
+
+.union-datasources .ordering .frame-header h4 a {
+	color: #fff;
+	border-color: rgba(255, 255, 255, 0.3);
 }

--- a/assets/uniondatasource.datasources.js
+++ b/assets/uniondatasource.datasources.js
@@ -1,69 +1,39 @@
-jQuery(document).ready(function() {
-	(function($) {
-		var $union_container = $('.UnionDatasource'),
-			$duplicator = $union_container.find('ol.union-duplicator'),
-			$sort = $union_container.find('select.sort-by'),
-			$order = $union_container.find('select.sort-order');
+(function($, Symphony) {
 
-		// Create our duplicator with ordering
-		$duplicator.symphonyDuplicator({
-			orderable: true,
-		});
+	Symphony.Extensions.UnionDatasource = function() {
 
-		// Update the Sort By/Order
-		var update = function() {
-			$duplicator.find('li:first').each(function() {
-				var $self = $(this),
-					sort = $self.find('input[name*=union-sort]').val(),
-					order = $self.find('input[name*=union-order]').val(),
-					$existing_sort = $sort.find('option').filter(function() {
-						return $(this).text() === sort;
-					}),
-					$existing_order = $order.find('option').filter(function() {
-						return $(this).text() === order;
-					});
+		var init = function() {
+			var	context = $('#ds-context'),
+				settings = $('.settings'),
+				conditions = settings.has('[name="fields[required_url_param]"]'),
+				pagination = settings.has('[name="fields[page_number]"]'),
+				datasources = $('.union-datasources');
 
-				// If this sort field already exists, select it
-				if($existing_sort.length) {
-					$existing_sort.attr('selected', 'selected');
-				}
-				// Otherwise add a new option and select it
-				else {
-					$sort.append(
-						$('<option />').attr('selected', 'selected').val(sort).text(sort)
-					);
-				}
+			// Relocate Union Data Source settings
+			datasources.parents('.settings').insertBefore(pagination);
 
-				// If this order already exists, select it
-				if($existing_order.length) {
-					$existing_order.attr('selected', 'selected');
-				}
-				// Otherwise add a new option and select it
-				else {
-					$order.append(
-						$('<option />').attr('selected', 'selected').val(order).text(order)
-					);
-				}
+			// Create Data Source selector
+			datasources.symphonyDuplicator({
+				orderable: true
 			});
+
+			// Set context
+			conditions.attr('data-context', conditions.attr('data-context') + ' union-datasource');
+			pagination.attr('data-context', pagination.attr('data-context') + ' union-datasource');
+
+			// Update context
+			context.trigger('change.admin');
 		}
 
-		// Trigger inital Sort By/Order population
-		update();
+		// API
+		return {
+			init: init
+		};
+	}();
 
-		$duplicator.closest('.frame')
-			// Listen for when the duplicator changes
-			// Update the sort options
-			.bind('orderstop.duplicator click.duplicator', update)
+	// Initialise backend
+	$(document).ready(function() {
+		Symphony.Extensions.UnionDatasource.init();
+	});
 
-			// When removing a duplicator item
-			.bind('destruct.duplicator', function() {
-				if($duplicator.find('li').length) {
-					update();
-				}
-				else {
-					$sort.add($order).find('option').remove();
-				}
-			});
-
-	})(jQuery.noConflict());
-});
+})(window.jQuery, window.Symphony);

--- a/data-sources/datasource.union.php
+++ b/data-sources/datasource.union.php
@@ -210,7 +210,8 @@
 			Administration::instance()->Page->addScriptToHead(URL . '/extensions/uniondatasource/assets/uniondatasource.datasources.js', 104);
 
 			$fieldset = new XMLElement('fieldset');
-			$fieldset->setAttribute('class', 'settings contextual ' . $class);
+			$fieldset->setAttribute('class', 'settings contextual');
+			$fieldset->setAttribute('data-context', 'union-datasource');
 			$fieldset->appendChild(new XMLElement('legend', self::getName()));
 
 			$p = new XMLElement('p', __('These data sources will have their output combined into a single data source and executed in this order.'));
@@ -219,15 +220,18 @@
 
 			// Datasources
 			$div = new XMLElement('div');
-			$p = new XMLElement('p', __('Add data sources to union'));
-			$p->appendChild(new XMLElement('i', __('Optional')));
+			$p = new XMLElement('p', __('Data Sources'));
+			$p->appendChild(new XMLElement('i', __('The first source determines sort order and direction')));
 			$p->setAttribute('class', 'label');
 			$div->appendChild($p);
 
+			$frame = new XMLElement('div');
+			$frame->setAttribute('class', 'frame union-datasources');
+
 			$ol = new XMLElement('ol');
-			$ol->setAttribute('class', 'union-duplicator');
 			$ol->setAttribute('data-add', __('Add data source'));
 			$ol->setAttribute('data-remove', __('Remove data source'));
+			$frame->appendChild($ol);
 
 			$datasources = self::getValidDatasources();
 			$i = 0;
@@ -306,89 +310,14 @@
 
 			if(isset($errors[$class]['union'])) {
 				$div->appendChild(
-					Widget::Error($ol, $errors[$class]['union'])
+					Widget::Error($frame, $errors[$class]['union'])
 				);
 			}
 			else {
-				$div->appendChild($ol);
+				$div->appendChild($frame);
 			}
 
 			$fieldset->appendChild($div);
-			$wrapper->appendChild($fieldset);
-
-		// Add Sorting/Pagination
-			$fieldset = new XMLElement('fieldset');
-			$fieldset->setAttribute('class', 'settings contextual ' . $class);
-			$fieldset->appendChild(new XMLElement('legend', __('Sorting and Limiting')));
-
-			$p = new XMLElement('p', __('All sorting is defined by the first data source in the union. Use <code>{$param}</code> syntax to limit pagination by page parameters.'));
-			$p->setAttribute('class', 'help');
-			$fieldset->appendChild($p);
-
-			$div = new XMLElement('div');
-			$div->setAttribute('class', 'group');
-
-			$label = Widget::Label(__('Sort By'));
-			$options = array();
-
-			$label->appendChild(Widget::Select('fields[sort]', $options, array(
-				'class' => 'sort-by',
-				'disabled' => 'disabled'
-			)));
-			$div->appendChild($label);
-
-			$label = Widget::Label(__('Sort Order'));
-
-			$sort_ds_order = isset($sort_ds->dsParamORDER) ? $sort_ds->dsParamORDER : 'asc';
-			$options = array(
-				array('asc', ('asc' == $sort_ds_order), __('ascending')),
-				array('desc', ('desc' == $sort_ds_order), __('descending')),
-				array('random', ('random' == $sort_ds_order), __('random')),
-			);
-
-			$label->appendChild(Widget::Select('fields[' . $class . '][order]', $options, array(
-				'class' => 'sort-order',
-				'disabled' => 'disabled'
-			)));
-			$div->appendChild($label);
-
-			$fieldset->appendChild($div);
-
-			$label = Widget::Label();
-			$input = array(
-				Widget::Input('fields[' . $class . '][paginate_results]', NULL, 'checkbox', (isset($settings['paginate_results']) && $settings['paginate_results'] == 'yes' ? array('checked' => 'checked') : NULL)),
-				Widget::Input('fields[' . $class . '][max_records]', isset($settings['max_records']) ? $settings['max_records'] : '10', NULL, array('size' => '6', 'type' => 'text')),
-				Widget::Input('fields[' . $class . '][page_number]', isset($settings['page_number']) ? $settings['page_number'] : '1', NULL, array('size' => '6', 'type' => 'text'))
-			);
-			$label->setValue(__('%s Paginate results, limiting to %s entries per page. Return page %s', array($input[0]->generate(false), $input[1]->generate(false), $input[2]->generate(false))));
-
-			if(isset($errors[self::getClass()]['max_records'])) $fieldset->appendChild(Widget::Error($label, $errors[$class]['max_records']));
-			else if(isset($errors[self::getClass()]['page_number'])) $fieldset->appendChild(Widget::Error($label, $errors[$class]['page_number']));
-			else $fieldset->appendChild($label);
-
-			$p = new XMLElement('p', __('Failing to paginate may degrade performance if the number of entries returned is very high.'), array('class' => 'help'));
-			$fieldset->appendChild($p);
-
-			$wrapper->appendChild($fieldset);
-
-			$fieldset = new XMLElement('fieldset');
-			$fieldset->setAttribute('class', 'settings contextual ' . $class);
-			$fieldset->appendChild(new XMLElement('legend', __('Output Options')));
-
-			$label = Widget::Label(__('Required URL Parameter'));
-			$label->appendChild(new XMLElement('i', __('Optional')));
-			$label->appendChild(Widget::Input('fields[' . $class . '][required_url_param]', isset($settings['required_url_param']) ? trim($settings['required_url_param']) : null));
-			$fieldset->appendChild($label);
-
-			$p = new XMLElement('p', __('An empty result will be returned when this parameter does not have a value. Do not wrap the parameter with curly-braces.'));
-			$p->setAttribute('class', 'help');
-			$fieldset->appendChild($p);
-
-			$label = Widget::Label();
-			$input = Widget::Input('fields[' . $class . '][redirect_on_empty]', 'yes', 'checkbox', (isset($settings['redirect_on_empty']) && $settings['redirect_on_empty'] == 'yes') ? array('checked' => 'checked') : NULL);
-			$label->setValue(__('%s Redirect to 404 page when no results are found', array($input->generate(false))));
-			$fieldset->appendChild($label);
-
 			$wrapper->appendChild($fieldset);
 		}
 


### PR DESCRIPTION
This pull request makes the interface compatible with Symphony 2.4. A few things that need to be done as a consequence:
- The editor no longer displays sort order and directions in the interface because those values are determined by the first selected Data Source. These values will no longer be posted when saving the DS so they need to be discovered in the PHP
- The editor now displays the default settings panels for pagination and conditions. The logic on the PHP side needs to be updated to match the core field names.
- Symphony 2.4 offers a new condition: a forbidden parameter. UDS needs to be updated to respect this setting.
