### PR TITLE
Display sorting context

### DIFF
--- a/assets/uniondatasource.datasources.js
+++ b/assets/uniondatasource.datasources.js
@@ -44,9 +44,6 @@
 		var displaySorting = function() {
 			var first = datasources.find('.instance:visible');
 
-				console.log('display');
-				console.log(first);
-
 			if(!datasources.is('.empty')) {
 				var field = first.find('[name="fields[UnionDatasource][union-sort][0]"]'),
 					direction = first.find('[name="fields[UnionDatasource][union-order][0]"]');


### PR DESCRIPTION
Adds a help text with the current sort field and direction on top of the Duplicator.
If no Data Source is selected yet, it displays `The first source determines sort order and direction`.
