### PR TITLE
Don't escape formatted textarea output - Fixes #43

### DIFF
--- a/data-sources/datasource.union.php
+++ b/data-sources/datasource.union.php
@@ -875,7 +875,7 @@
 					if (!$datasource->_param_output_only) foreach ($datasource->dsParamINCLUDEDELEMENTS as $handle) {
 						list($handle, $mode) = preg_split('/\s*:\s*/', $handle, 2);
 						if(self::$field_pool[$field_id]->get('element_name') == $handle) {
-							self::$field_pool[$field_id]->appendFormattedElement($xEntry, $values, ($datasource->dsParamHTMLENCODE ? true : false), $mode, $entry->get('id'));
+							self::$field_pool[$field_id]->appendFormattedElement($xEntry, $values, ($datasource->dsParamHTMLENCODE === 'yes' ? true : false), $mode, $entry->get('id'));
 						}
 					}
 				}
@@ -982,10 +982,22 @@
 
 		public function setDatasourceAssociatedEntryCounts(Datasource $datasource, XMLElement &$xEntry, Entry $entry) {
 			$associated_entry_counts = $entry->fetchAllAssociatedEntryCounts($datasource->_associated_sections);
-			if(!empty($associated_entry_counts)){
-				foreach($associated_entry_counts as $section_id => $count){
-					foreach($datasource->_associated_sections as $section) {
-						if ($section['id'] == $section_id) $xEntry->setAttribute($section['handle'], (string)$count);
+			
+			if (!empty($associated_entry_counts)) {
+				foreach ($associated_entry_counts as $section_id => $fields) {
+					foreach ($datasource->_associated_sections as $section) {
+						if ($section['id'] != $section_id) continue;
+
+						// For each related field show the count (#2083)
+						foreach($fields as $field_id => $count) {
+							$field_handle = FieldManager::fetchHandleFromID($field_id);
+							if($field_handle) {
+								$xEntry->setAttribute($section['handle'] . '-' . $field_handle, (string)$count);
+							}
+
+							// Backwards compatibility (without field handle)
+							$xEntry->setAttribute($section['handle'], (string)$count);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Hi,

I compared changes in the core to fix the escaped formatted textarea (issue #43).  I'm not too familiar with pull requests, so hope this ok.

Aonrud