### PR TITLE
Fixed duplicated parameters (#42)

### DIFF
--- a/data-sources/datasource.union.php
+++ b/data-sources/datasource.union.php
@@ -1064,8 +1064,7 @@
 					if($singleParam) $datasource->_param_pool[$key][] = $param_pool_values;
 				}
 			}
-   //remove params due to duplicated param bug(?)
-			//$param_pool = array_merge_recursive($param_pool, $datasource->_param_pool);
+			$param_pool = array_replace_recursive($param_pool, $datasource->_param_pool);
 		}
 	}
 

--- a/data-sources/datasource.union.php
+++ b/data-sources/datasource.union.php
@@ -1064,8 +1064,8 @@
 					if($singleParam) $datasource->_param_pool[$key][] = $param_pool_values;
 				}
 			}
-
-			$param_pool = array_merge_recursive($param_pool, $datasource->_param_pool);
+   //remove params due to duplicated param bug(?)
+			//$param_pool = array_merge_recursive($param_pool, $datasource->_param_pool);
 		}
 	}
 


### PR DESCRIPTION
Changed `array_merge_recursive` to `array_replace_recursive` prevents the duplicating of parameters 